### PR TITLE
Fix(deeplink): android routes in deep link fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.0.4]
+#### Added
+- increase list length to 30 items
+- QuickPick stay open even when loosing UI focus
+#### Fixed
+- android deeplink fails
 ## [0.0.1]
-
 - Initial release

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "deeplink",
-	"displayName": "Deeplink (Android / iOS)",
+	"displayName": "Deep link (Android / iOS)",
 	"description": "Open deeplink in mobile emulators",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"publisher": "emanuel-braz",
 	"repository": {
 		"type": "git",
@@ -24,20 +24,20 @@
 	"contributes": {
 		"commands": [
 			{
-				"title": "Deeplink: open in Android",
+				"title": "Deep link: in Android",
 				"command": "extension.androidDeeplink"
 			},
 			{
-				"title": "Deeplink: clear cache",
-				"command": "extension.deeplinkClearCache"
-			},
-			{
-				"title": "Deeplink: open in iOS",
+				"title": "Deep link: in iOS",
 				"command": "extension.iosDeeplink",
 				"enablement": "isMac"
 			},
 			{
-				"title": "Deeplink: open last prompt",
+				"title": "Deep link: clear the list",
+				"command": "extension.deeplinkClearCache"
+			},
+			{
+				"title": "Deep link: run last command",
 				"command": "extension.lastPromptDeeplink",
 				"enablement": "false"
 			}

--- a/src/core/consts/app_consts.ts
+++ b/src/core/consts/app_consts.ts
@@ -1,4 +1,4 @@
-export const MAX_ITENS = 10;
+export const MAX_ITENS = 30;
 export const ANDROID_EXEC = "adb";
 export const IOS_EXEC = "xcrun";
 export const LINKS_KEY = "links_key";

--- a/src/core/dialogs/dialogs.ts
+++ b/src/core/dialogs/dialogs.ts
@@ -43,6 +43,7 @@ export class Dialogs {
             const quickPick = window.createQuickPick();
             quickPick.placeholder = placeHolder;
             quickPick.items = options.map(label => ({ label }));
+            quickPick.ignoreFocusOut = true;
 
             quickPick.onDidChangeSelection((selection: QuickPickItem[]) => {
                 const valueSelected = selection[0].label;

--- a/src/core/runners/runner.ts
+++ b/src/core/runners/runner.ts
@@ -4,7 +4,7 @@ const { exec } = require("child_process");
 export class Runner {
 
     static runAndroid(route: string = "") {
-        return run(`adb shell am start -d ${route}`);
+        return run(`adb shell am start -W -a android.intent.action.VIEW -d ${route}`);
     }
 
     static runIos(route: string) {


### PR DESCRIPTION
#### Added
- increase list length to 30 items
- QuickPick stay open even when loosing UI focus
#### Fixed
- android deeplink fails